### PR TITLE
Switch NewComputerModernMath to use Book weight

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -274,14 +274,14 @@ NewComputerModern/newcomputermodern:
 
 NewComputerModern: NewComputerModern/newcomputermodern
 	# Copy the fonts and doc and convert them into WOFF
-	cp $</otf/NewCMMath-Regular.otf $@
+	cp $</otf/NewCMMath-Book.otf $@
 	cp $</GUST-FONT-LICENSE.txt $@
-	cd $@; $(COMPRESS) NewCMMath-Regular.otf ; rm NewCMMath-Regular.otf
+	cd $@; $(COMPRESS) NewCMMath-Book.otf ; rm NewCMMath-Book.otf
 	# Generate CheckFont logs
-	@PYTHON@ CheckFont.py $@/NewCMMath-Regular.woff \
+	@PYTHON@ CheckFont.py $@/NewCMMath-Book.woff \
 	> $@/CheckFontLog.txt 2> $@/CheckFontError.txt
 	# Generate the testcase
-	@PYTHON@ GenerateHTMLTest.py $@ NewCMMath-Regular.woff
+	@PYTHON@ GenerateHTMLTest.py $@ NewCMMath-Book.woff
 
 NewComputerModernSans: NewComputerModern/newcomputermodern
 	# Copy the fonts and doc and convert them into WOFF

--- a/NewComputerModern/mathfonts.css
+++ b/NewComputerModern/mathfonts.css
@@ -12,8 +12,8 @@ to woff.
 
 @font-face {
     font-family: NewComputerModernMath;
-    src: local('NewComputerModernMath'), local('NewComputerModernMath-Regular'),
-         url('NewCMMath-Regular.woff2'), url('NewCMMath-Regular.woff');
+    src: local('NewComputerModernMath'),
+         url('NewCMMath-Book.woff2'), url('NewCMMath-Book.woff');
 }
 
 .htmlmathparagraph, m|mtext {


### PR DESCRIPTION
fontconfig already prefers the Book variant over the Regular:
```
$ fc-match NewComputerModernMath
NewCMMath-Book.otf: "NewComputerModernMath" "Book"
```
for local fonts, thus update the url-based font definition to also use the Book weight.

See discussion here: https://github.com/fred-wang/MathFonts/issues/15