### PR TITLE
Fix font_data page list link target / text mixup

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
               if (value == "Default")
                   continue;
               font_data.insertAdjacentHTML("beforeend",
-                                           `<li><a href="${mathfont_list[value]}/">${value}</a></li>`);
+                                           `<li><a href="${value}/">${mathfont_list[value]}</a></li>`);
           }
       });
     </script>


### PR DESCRIPTION
The link target for the entries at the end of the page were set to the "full names" instead of the id forms. Switch the two so that the links work.